### PR TITLE
Research nav module

### DIFF
--- a/FlightCode/Makefile
+++ b/FlightCode/Makefile
@@ -29,6 +29,10 @@ GUIDANCE = guidance/straight_level.c
 #NAVIGATION = navigation/micronav_ahrs.c
 NAVIGATION = navigation/EKF_15state_quat.c
 
+##### RESEARCH NAVIGATION #####
+# Point to the desired navigation code here
+RESEARCHNAVIGATION = researchNavigation/empty_nav.c
+
 ##### FLIGHT CONTROL LAW #####
 # Point to the desired flight control law code here
 CONTROL =  control/baseline_control.c
@@ -126,6 +130,7 @@ datalog/datalogger.c \
 sensors/daq.c \
 $(GUIDANCE) \
 $(NAVIGATION) \
+$(RESEARCHNAVIGATION) \
 $(CONTROL) \
 $(SYSTEM_ID) \
 $(SURFACE_FAULT) \
@@ -196,6 +201,7 @@ display:
 	@ echo "DATALOG = $(DATALOG_CONFIG)"
 	@ echo "GUIDANCE = $(GUIDANCE)"
 	@ echo "NAVIGATION = $(NAVIGATION)"
+	@ echo "RESEARCH NAVIGATION = $(RESEARCHNAVIGATION)"
 	@ echo "CONTROL = $(CONTROL)"
 	@ echo "SYSTEM_ID = $(SYSTEM_ID)"
 	@ echo "SURFACE_FAULT = $(SURFACE_FAULT)"

--- a/FlightCode/Makefile
+++ b/FlightCode/Makefile
@@ -26,8 +26,8 @@ GUIDANCE = guidance/straight_level.c
 
 ##### NAVIGATION #####
 # Point to the desired navigation code here
-#NAVIGATION = navigation/micronav_ahrs.c
-NAVIGATION = navigation/EKF_15state_quat.c
+NAVIGATION = navigation/micronav_ahrs.c
+#NAVIGATION = navigation/EKF_15state_quat.c
 
 ##### RESEARCH NAVIGATION #####
 # Point to the desired navigation code here

--- a/FlightCode/globaldefs.h
+++ b/FlightCode/globaldefs.h
@@ -233,6 +233,46 @@ struct nav {
 	double signal_9;     ///< user defined dummy variable
 };
 
+/// Research Navigation Filter Data Structure
+struct researchNav {
+	double lat;		///< [rad], geodetic latitude estimate
+	double lon;		///< [rad], geodetic longitude estimate
+	double alt;		///< [m], altitude relative to WGS84 estimate
+	double vn;		///< [m/sec], north velocity estimate
+	double ve;		///< [m/sec], east velocity estimate
+	double vd;		///< [m/sec], down velocity estimate
+	double phi;		///< [rad], Euler roll angle estimate
+	double the;		///< [rad], Euler pitch angle estimate
+	double psi;		///< [rad], Euler yaw angle estimate
+	double quat[4];	///< Quaternions estimate
+	double ab[3];	///< [m/sec^2], accelerometer bias estimate
+	double gb[3];	///< [rad/sec], rate gyro bias estimate
+	double asf[3];	///< [m/sec^2], accelerometer scale factor estimate
+	double gsf[3];	///< [rad/sec], rate gyro scale factor estimate
+	double Pp[3];	///< [rad], covariance estimate for position
+	double Pv[3];	///< [rad], covariance estimate for velocity
+	double Pa[3];	///< [rad], covariance estimate for angles
+	double Pab[3];	///< [rad], covariance estimate for accelerometer bias
+	double Pgb[3];	///< [rad], covariance estimate for rate gyro bias
+	double Pasf[3];	///< [rad], covariance estimate for accelerometer scale factor
+	double Pgsf[3];	///< [rad], covariance estimate for rate gyro scale factor
+	enum errdefs err_type;	///< NAV filter status
+	double time;			///< [sec], timestamp of NAV filter
+	double wn;			///< [m/s], estimated wind speed in the north direction
+	double we;			///< [m/s], estimated wind speed in the east direction
+	double wd;			///< [m/s], estimated wind speed in the down direction
+	double signal_0;     ///< user defined dummy variable
+	double signal_1;     ///< user defined dummy variable
+	double signal_2;     ///< user defined dummy variable
+	double signal_3;     ///< user defined dummy variable
+	double signal_4;     ///< user defined dummy variable
+	double signal_5;     ///< user defined dummy variable
+	double signal_6;     ///< user defined dummy variable
+	double signal_7;     ///< user defined dummy variable
+	double signal_8;     ///< user defined dummy variable
+	double signal_9;     ///< user defined dummy variable
+};
+
 /// Combined sensor data structure
 struct sensordata {
 	struct imu *imuData_ptr; 			///< pointer to imu data structure

--- a/FlightCode/globaldefs.h
+++ b/FlightCode/globaldefs.h
@@ -156,8 +156,9 @@ struct inceptor {
 
 /// Mission manager Data structure
 struct mission {
-	unsigned short mode;///< mode variable; 0 = dump data, 1 = manual control, 2 = autopilot control
-	unsigned short run_num;///< counter for number of autopilot engagements
+	unsigned short mode;		///< mode variable; 0 = dump data, 1 = manual control, 2 = autopilot control
+	unsigned short run_num;		///< counter for number of autopilot engagements
+	unsigned short researchNav;	///< mode variable; 0 = standard nav filter, 1 = research nav filter
 };
 
 /// Control Data structure

--- a/FlightCode/main.c
+++ b/FlightCode/main.c
@@ -30,6 +30,7 @@
 #include "sensors/daq_interface.h"
 #include "actuators/actuator_interface.h"
 #include "navigation/nav_interface.h"
+#include "researchNavigation/researchnav_interface.h"
 #include "guidance/guidance_interface.h"
 #include "control/control_interface.h"
 #include "system_id/systemid_interface.h"
@@ -56,14 +57,15 @@ trigger_actuators,  trigger_datalogger, trigger_telemetry;
 int main(int argc, char **argv) {
 
 	// Data Structures
-	struct 	mission 	missionData;
-	struct  nav   		navData;
-	struct  control 	controlData;
-	struct  imu   		imuData;
-	struct  gps   		gpsData;
-	struct  airdata 	adData;
-	struct  surface 	surfData;
-	struct  inceptor 	inceptorData;
+	struct 	mission 		missionData;
+	struct  nav   			navData;
+	struct  researchNav   	researchNavData;
+	struct  control 		controlData;
+	struct  imu   			imuData;
+	struct  gps   			gpsData;
+	struct  airdata 		adData;
+	struct  surface 		surfData;
+	struct  inceptor 		inceptorData;
 
 	// Additional data structures for GPS FASER
 	struct  gps   gpsData_l;
@@ -137,9 +139,10 @@ int main(int argc, char **argv) {
 	init_telemetry();
 
 	while(1){
-		missionData.mode = 1; 				// initialize to manual mode
-		missionData.run_num = 0; 			// reset run counter
-		navData.err_type = got_invalid;		// initialize nav filter as invalid
+		missionData.mode = 1; 						// initialize to manual mode
+		missionData.run_num = 0; 					// reset run counter
+		navData.err_type = got_invalid;				// initialize nav filter as invalid
+		researchNavData.err_type = got_invalid;	// initialize research nav filter as invalid
 
 		//initialize real time clock at zero
 		reset_Time();
@@ -175,6 +178,16 @@ int main(int argc, char **argv) {
 			}
 			else
 				get_nav(&sensorData, &navData, &controlData);// Call NAV filter
+			
+			//**** RESEARCH NAVIGATION ***********************************************
+			if(researchNavData.err_type == got_invalid){ // check if research NAV filter has been initialized
+
+					if(gpsData.navValid == 0) // check if GPS is locked, comment out if using micronav_ahrs
+
+					init_researchNav(&sensorData, &researchNavData);// Initialize research NAV filter
+			}
+			else
+				get_researchNav(&sensorData, &researchNavData);// Call research NAV filter
 
 			etime_nav = get_Time() - tic - etime_daq; // compute execution time			
 			//************************************************************************

--- a/FlightCode/main.c
+++ b/FlightCode/main.c
@@ -59,6 +59,7 @@ int main(int argc, char **argv) {
 	// Data Structures
 	struct 	mission 		missionData;
 	struct  nav   			navData;
+	struct  nav   			tempNavData;
 	struct  researchNav   	researchNavData;
 	struct  control 		controlData;
 	struct  imu   			imuData;
@@ -141,8 +142,9 @@ int main(int argc, char **argv) {
 	while(1){
 		missionData.mode = 1; 						// initialize to manual mode
 		missionData.run_num = 0; 					// reset run counter
+		missionData.researchNav = 0;				// initialize to use standard nav filter in feedback
 		navData.err_type = got_invalid;				// initialize nav filter as invalid
-		researchNavData.err_type = got_invalid;	// initialize research nav filter as invalid
+		researchNavData.err_type = got_invalid;		// initialize research nav filter as invalid
 
 		//initialize real time clock at zero
 		reset_Time();
@@ -172,7 +174,7 @@ int main(int argc, char **argv) {
 			//**** NAVIGATION ********************************************************
 			if(navData.err_type == got_invalid){ // check if NAV filter has been initialized
 
-					if(gpsData.navValid == 0) // check if GPS is locked, comment out if using micronav_ahrs
+					//if(gpsData.navValid == 0) // check if GPS is locked, comment out if using micronav_ahrs
 
 					init_nav(&sensorData, &navData, &controlData);// Initialize NAV filter
 			}
@@ -182,7 +184,7 @@ int main(int argc, char **argv) {
 			//**** RESEARCH NAVIGATION ***********************************************
 			if(researchNavData.err_type == got_invalid){ // check if research NAV filter has been initialized
 
-					if(gpsData.navValid == 0) // check if GPS is locked, comment out if using micronav_ahrs
+					//if(gpsData.navValid == 0) // check if GPS is locked, comment out if using micronav_ahrs
 
 					init_researchNav(&sensorData, &researchNavData);// Initialize research NAV filter
 			}
@@ -191,6 +193,11 @@ int main(int argc, char **argv) {
 
 			etime_nav = get_Time() - tic - etime_daq; // compute execution time			
 			//************************************************************************
+
+			if(missionData.researchNav == 1){	// use research nav filter for feedback
+				memcpy(&tempNavData,&navData,sizeof(navData));					// copy nav data into temp struct
+				memcpy(&navData,&researchNavData,sizeof(researchNavData));		// copy research nav data into nav data
+			}
 
 			if (missionData.mode == 2) { // autopilot mode
 				if (t0_latched == FALSE) {
@@ -242,6 +249,10 @@ int main(int argc, char **argv) {
 			etime_actuators = get_Time() - tic - ACTUATORS_OFFSET; // compute execution time
 			//************************************************************************
 
+			if(missionData.researchNav == 1){	// use research nav filter for feedback
+				memcpy(&navData,&tempNavData,sizeof(tempNavData));					// copy nav data back for data logging
+			}
+			
 			//**** DATA LOGGING ******************************************************
 			datalogger();
 			etime_datalog = get_Time() - tic - etime_actuators - ACTUATORS_OFFSET; // compute execution time

--- a/FlightCode/researchNavigation/empty_nav.c
+++ b/FlightCode/researchNavigation/empty_nav.c
@@ -1,0 +1,85 @@
+/*!
+ * \author University of Minnesota
+ * \author Aerospace Engineering and Mechanics
+ * \copyright Copyright 2011 Regents of the University of Minnesota. All rights reserved.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <termios.h>
+#include <math.h>
+#include <pthread.h>
+#include <sched.h>
+#include <cyg/posix/pthread.h>
+#include <cyg/kernel/kapi.h>
+#include <cyg/cpuload/cpuload.h>
+
+#include "../globaldefs.h"
+#include "../extern_vars.h"
+#include "../utils/matrix.h"
+#include "../utils/misc.h"
+
+#include "../navigation/nav_functions.h"
+#include "researchnav_interface.h"
+
+void init_researchNav(struct sensordata *sensorData_ptr, struct researchNav *researchNavData_ptr){
+
+	researchNavData_ptr->lat = sensorData_ptr->gpsData_ptr->lat*D2R;
+	researchNavData_ptr->lon = sensorData_ptr->gpsData_ptr->lon*D2R;
+	researchNavData_ptr->alt = sensorData_ptr->gpsData_ptr->alt;
+	
+	researchNavData_ptr->vn = sensorData_ptr->gpsData_ptr->vn;
+	researchNavData_ptr->ve = sensorData_ptr->gpsData_ptr->ve;
+	researchNavData_ptr->vd = sensorData_ptr->gpsData_ptr->vd;
+
+	researchNavData_ptr->the = 8*D2R;
+	researchNavData_ptr->phi = 0*D2R;
+	researchNavData_ptr->psi = 90.0*D2R;
+
+	researchNavData_ptr->ab[0] = 0.0;
+	researchNavData_ptr->ab[1] = 0.0; 
+	researchNavData_ptr->ab[2] = 0.0;
+	
+	researchNavData_ptr->gb[0] = sensorData_ptr->imuData_ptr->p;
+	researchNavData_ptr->gb[1] = sensorData_ptr->imuData_ptr->q;
+	researchNavData_ptr->gb[2] = sensorData_ptr->imuData_ptr->r;
+	
+	researchNavData_ptr->err_type = data_valid;
+	send_status("Research NAV filter initialized");
+}
+
+// Main get_nav filter function
+void get_researchNav(struct sensordata *sensorData_ptr, struct researchNav *researchNavData_ptr){
+	
+	researchNavData_ptr->lat = sensorData_ptr->gpsData_ptr->lat*D2R;
+	researchNavData_ptr->lon = sensorData_ptr->gpsData_ptr->lon*D2R;
+	researchNavData_ptr->alt = sensorData_ptr->gpsData_ptr->alt;
+	
+	researchNavData_ptr->vn = sensorData_ptr->gpsData_ptr->vn;
+	researchNavData_ptr->ve = sensorData_ptr->gpsData_ptr->ve;
+	researchNavData_ptr->vd = sensorData_ptr->gpsData_ptr->vd;
+
+	researchNavData_ptr->the = 8*D2R;
+	researchNavData_ptr->phi = 0*D2R;
+	researchNavData_ptr->psi = 90.0*D2R;
+
+	researchNavData_ptr->ab[0] = 0.0;
+	researchNavData_ptr->ab[1] = 0.0; 
+	researchNavData_ptr->ab[2] = 0.0;
+	
+	researchNavData_ptr->gb[0] = sensorData_ptr->imuData_ptr->p;
+	researchNavData_ptr->gb[1] = sensorData_ptr->imuData_ptr->q;
+	researchNavData_ptr->gb[2] = sensorData_ptr->imuData_ptr->r;
+	
+	researchNavData_ptr->err_type = gps_aided;
+	send_status("Research NAV filter initialized");
+
+}
+
+void close_researchNav(void){
+	
+}

--- a/FlightCode/researchNavigation/researchnav_interface.h
+++ b/FlightCode/researchNavigation/researchnav_interface.h
@@ -1,0 +1,32 @@
+/*!
+ * \author University of Minnesota
+ * \author Aerospace Engineering and Mechanics
+ * \copyright Copyright 2011 Regents of the University of Minnesota. All rights reserved.
+ */
+
+/// Standard function to initialize the navigation filter.
+/*!
+ * \sa get_nav(), close_nav()
+ * \ingroup nav_fcns
+*/
+void init_researchNav(struct sensordata *sensorData_ptr,	///< pointer to sensorData structure
+		struct researchNav *researchNavData_ptr			///< pointer to navData structure
+		);
+
+/// Standard function to call the navigation filter.
+/*!
+ * \sa init_nav(), close_nav()
+ * \ingroup nav_fcns
+*/
+void get_researchNav(struct sensordata *sensorData_ptr,	///< pointer to sensorData structure
+		struct researchNav *researchNavData_ptr			///< pointer to navData structure
+		);
+
+/// Standard function to close the navigation filter.
+/*!
+ * No input or return parameters
+ * \sa get_nav(), init_nav()
+ * \ingroup nav_fcns
+*/
+void close_researhcNav(void);
+


### PR DESCRIPTION
A research navigation module was added located in the researchNavigation folder and an empty navigation filter was created to demonstrate the input and output planes. The purpose of adding this module is to enable running an early stage module in flight while using a validated module for feedback. In addition to adding this folder and empty filter, a researchNavData structure was created to store and log data for this module based off the current 15 state quaternion based EKF filter.

The research navigation module can be switched to feedback to the rest of the code by setting missionData.researchNav to 1. This switching functionality is not currently transient free; it is a hard switch. The switch works by using memcpy to move the standard navigation filter data to a temporary structure, copying the research navigation filter data to the navigation data structure, running the rest of the flight code, and copying the the temporary structure back to the navigation data structure for data logging.